### PR TITLE
never panic on external errors

### DIFF
--- a/blocklist_updater.go
+++ b/blocklist_updater.go
@@ -45,7 +45,8 @@ func (u *BlocklistUpdater) Start() {
 		if !u.persistBlocklists || !exists(u.persistencePath) {
 			bm, err := GenerateBlockageMap(u.Plugin.BlockLists)
 			if err != nil {
-				panic("Failed to fetch blocklists")
+				log.Error(err)
+				return
 			}
 			u.Plugin.blockMap = bm
 			persistLoadedBlocklist(u, u.Enabled, u.Plugin.BlockLists, bm, u.persistencePath)
@@ -59,7 +60,8 @@ func (u *BlocklistUpdater) Start() {
 				!u.Enabled {
 				bm, err := GenerateBlockageMap(u.Plugin.BlockLists)
 				if err != nil {
-					panic("Failed to fetch blocklists")
+					log.Error(err)
+					return
 				}
 				u.Plugin.blockMap = bm
 				persistLoadedBlocklist(u, u.Enabled, u.Plugin.BlockLists, bm, u.persistencePath)

--- a/blocklist_updater_test.go
+++ b/blocklist_updater_test.go
@@ -60,6 +60,28 @@ func TestBlocklistUpdater(t *testing.T) {
 	p.updater.updateTicker.Stop()
 }
 
+func TestBlocklistUpdaterWithBadList(t *testing.T) {
+	p := initTestPlugin(t, getEmptyRuleset())
+
+	p.BlockLists = []string{"https://badhost/doesnotexist"}
+	p.blockMap = make(BlockMap, 0)
+
+	updater := BlocklistUpdater{
+		Enabled:        false,
+		Plugin:         p,
+		UpdateInterval: time.Second * 2,
+		RetryCount:     10,
+		RetryDelay:     time.Second * 1,
+	}
+
+	p.updater = &updater
+	p.updater.Start()
+
+	// give it time to fail
+	time.Sleep(time.Second * 6)
+	assert.Equal(t, 0, len(p.blockMap))
+}
+
 func initTestServer(t *testing.T) *httptest.Server {
 	firstPath, err := os.Open(firstHostlistPath)
 	assert.NoError(t, err)


### PR DESCRIPTION
Tried your plugin and it works as long as there is no DNS/network or server defect. If there is, it crashes the whole coredns server. Tried to remove the two panics, replace them with error logs instead.