### PR TITLE
change plugin priority

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Next update
  the `plugin.cfg` in the root of the coredns repository
 
 ```bash
-sed -i 's|hosts:hosts|ads:github.com/c-mueller/ads\nhosts:hosts|g' plugin.cfg
+sed -i 's|loadbalance:loadbalance|ads:github.com/c-mueller/ads\nloadbalance:loadbalance|g' plugin.cfg
 ```
 
 Finally run `make` to build CoreDNS with the `ads` plugin


### PR DESCRIPTION
I ran into the error that the coredns cache plugin would override the blacklist introduced by this plugin. If you query a domain prior or while the blacklist is loaded (or is empty for whatever reason) you receive the correct IP even after the blacklist is loaded, due to the cache plugin having a higher order in the plugin.cfg then your current suggestion of `hosts:hosts` line.

Do you see any drawback putting it before the loadbalancer (blacklisted do not need to get balanced anyway)? Is the domain lookup in your blacklist fast enough?