### PR TITLE
Implement IDNA support for Lists

### DIFF
--- a/ads_idna_test.go
+++ b/ads_idna_test.go
@@ -1,0 +1,24 @@
+package ads
+
+import (
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/net/idna"
+	"testing"
+)
+
+var values = map[string]string{
+	"ɢoogle.com":          "xn--oogle-wmc.com",
+	"müller.c-mueller.de": "xn--mller-kva.c-mueller.de",
+	"mähl.c-mueller.de":   "xn--mhl-qla.c-mueller.de",
+	"💩.krnl.eu":          "xn--ls8h.krnl.eu",
+	"c-mueller.de":        "c-mueller.de",
+}
+
+func TestIDNADecode(t *testing.T) {
+	for k, v := range values {
+		result, err := idna.ToASCII(k)
+		assert.NoError(t, err)
+		t.Log(result)
+		assert.Equal(t, v, result)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -9,5 +9,5 @@ require (
 	github.com/miekg/dns v1.1.28
 	github.com/prometheus/client_golang v1.5.0
 	github.com/stretchr/testify v1.5.1
-	golang.org/x/net v0.0.0-20200301022130-244492dfa37a
+	golang.org/x/net v0.0.0-20200320181208-1c781a10960a
 )

--- a/list_map_handler.go
+++ b/list_map_handler.go
@@ -17,6 +17,7 @@
 package ads
 
 import (
+	"golang.org/x/net/idna"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -111,6 +112,12 @@ func parseListFile(data []byte, blockageMap ListMap) {
 		}
 
 		if url == "" {
+			continue
+		}
+
+		var err error
+		url, err = idna.ToASCII(url)
+		if err != nil {
 			continue
 		}
 

--- a/list_map_handler_test.go
+++ b/list_map_handler_test.go
@@ -52,6 +52,7 @@ func TestListFetch(t *testing.T) {
 	expData, err := ioutil.ReadAll(expectedList)
 
 	for _, url := range strings.Split(string(expData), "\n") {
+		t.Logf("Expected QName: %q Found: %v", url, list[url])
 		assert.True(t, list[url])
 	}
 	assert.False(t, list["testme.com"])

--- a/setup_parse.go
+++ b/setup_parse.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"github.com/caddyserver/caddy"
 	"github.com/coredns/coredns/plugin"
+	"golang.org/x/net/idna"
 	"net"
 	"net/url"
 	"time"
@@ -143,7 +144,12 @@ func parsePluginConfiguration(c *caddy.Controller) (*adsPluginConfig, error) {
 			if !c.NextArg() {
 				return nil, plugin.Error("ads", c.Err("No name for blacklist (block) entry defined"))
 			}
-			config.BlacklistRules = append(config.BlacklistRules, c.Val())
+			v := c.Val()
+			encoded, err := idna.ToASCII(v)
+			if err != nil {
+				return nil, plugin.Error("ads", c.Err(fmt.Sprintf("Could not decode IDN of qname %q", v)))
+			}
+			config.BlacklistRules = append(config.BlacklistRules, encoded)
 			break
 		case "block-regex":
 			if !c.NextArg() {
@@ -155,7 +161,12 @@ func parsePluginConfiguration(c *caddy.Controller) (*adsPluginConfig, error) {
 			if !c.NextArg() {
 				return nil, plugin.Error("ads", c.Err("No name for whitelist (permit) entry defined"))
 			}
-			config.WhitelistRules = append(config.WhitelistRules, c.Val())
+			v := c.Val()
+			encoded, err := idna.ToASCII(v)
+			if err != nil {
+				return nil, plugin.Error("ads", c.Err(fmt.Sprintf("Could not decode IDN of qname %q", v)))
+			}
+			config.WhitelistRules = append(config.WhitelistRules, encoded)
 			break
 		case "permit-regex":
 			if !c.NextArg() {

--- a/setup_test.go
+++ b/setup_test.go
@@ -92,6 +92,14 @@ const invalid_Blacklist_Multi = `ads {
   block
 }`
 
+const valid_IDN_Block = `ads {
+  block mähl.c-mueller.de
+}`
+
+const valid_IDN_Permit = `ads {
+  permit mähl.c-mueller.de
+}`
+
 const valid_Regex_Whitelist_Single = `ads {
   permit-regex (^|\.)local\.c-mueller\.de$
 }`
@@ -215,6 +223,8 @@ func TestSetup_ValidWhiteAndBlacklist(t *testing.T) {
 		valid_Blacklist_Single,
 		valid_Whitelist_Multi,
 		valid_Whitelist_Single,
+		valid_IDN_Block,
+		valid_IDN_Permit,
 	}
 
 	for _, v := range cfs {

--- a/testdata/test_blocklist
+++ b/testdata/test_blocklist
@@ -6,4 +6,6 @@
 0.0.0.0 ɢoogle.com
 0.0.0.0 müller.c-mueller.de
 0.0.0.0 mähl.krnl.eu
+0.0.0.0 mähl.c-mueller.de
 0.0.0.0 💩.krnl.eu
+0.0.0.0 c-mueller.de

--- a/testdata/test_blocklist
+++ b/testdata/test_blocklist
@@ -3,3 +3,7 @@
 #0.0.0.0    123.de
 0.0.0.0     test-123.de
 0.0.0.0          test.com
+0.0.0.0 ɢoogle.com
+0.0.0.0 müller.c-mueller.de
+0.0.0.0 mähl.krnl.eu
+0.0.0.0 💩.krnl.eu

--- a/testdata/test_blocklist_expected_domains
+++ b/testdata/test_blocklist_expected_domains
@@ -2,3 +2,8 @@ test.de
 testdomain.de
 test-123.de
 test.com
+xn--oogle-wmc.com
+xn--mller-kva.c-mueller.de
+xn--mhl-qla.c-mueller.de
+xn--ls8h.krnl.eu
+c-mueller.de

--- a/testdata/test_blocklist_expected_domains
+++ b/testdata/test_blocklist_expected_domains
@@ -5,5 +5,6 @@ test.com
 xn--oogle-wmc.com
 xn--mller-kva.c-mueller.de
 xn--mhl-qla.c-mueller.de
+xn--mhl-qla.krnl.eu
 xn--ls8h.krnl.eu
 c-mueller.de


### PR DESCRIPTION
Resolves #28 

Before passing processing URLs using the Ascii regex, they get passed through an IDNA decoder converting domains like `mähl.de` to 'xn--mhl-qla.de' making it conform to the regex and ready for blocking.