### PR TITLE
Fixed list fetching crash

### DIFF
--- a/list_map_handler.go
+++ b/list_map_handler.go
@@ -37,7 +37,8 @@ func GenerateListMap(urls []string, fetchFunc func(ref string) ([]byte, error)) 
 
 		data, err := fetchFunc(listUrl)
 		if err != nil {
-			return nil, err
+			log.Warningf("Loading list from url %q failed with error: %s", listUrl, err.Error())
+			continue
 		}
 		parseListFile(data, listMap)
 	}


### PR DESCRIPTION
Fixes #30

Instead of crashing completely if a download URL is unavailable, like before, the plugin now continues loading the lists, skipping the failed list.