### PR TITLE
Migrate to GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Go
 
 on:
   push:
-    branches: [ * ]
+    branches: [ '*' ]
   pull_request:
     branches: [ master ]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,34 @@
+name: Go
+
+on:
+  push:
+    branches: [ * ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+
+  test:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v2
+      with:
+        go-version: ^1.13
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+
+    - name: Get dependencies
+      run: |
+        go get -v -t -d ./...
+        if [ -f Gopkg.toml ]; then
+            curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+            dep ensure
+        fi
+
+    - name: Test
+      run: go test -v .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,27 +1,21 @@
 name: Go
-
 on:
   push:
     branches: [ '*' ]
   pull_request:
-    branches: [ master ]
-
+    branches: [ '*' ]
 jobs:
-
   test:
-    name: Build
+    name: Test + Coverage
     runs-on: ubuntu-latest
     steps:
-
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
         go-version: ^1.13
       id: go
-
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
-
     - name: Get dependencies
       run: |
         go get -v -t -d ./...
@@ -29,6 +23,8 @@ jobs:
             curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
             dep ensure
         fi
-
     - name: Test
-      run: go test -v .
+      run: go test -coverprofile=coverage.txt -covermode=atomic -v .
+    - name: Codecov
+      uses: codecov/codecov-action@v1.0.13
+    


### PR DESCRIPTION
The Goal of this PR is to move away From Drone and to compile `ads` using GitHub Actions.

This therefore introduces three new Checks:
- [ ] Test: Used to run the Unit tests and to determine the coverage
- [ ] Build `master`: Used to Compile the plugin against the latest revision of coredns (master branch)
- [ ] Build `release`: Used to compile the plugin against the latest release of coredns